### PR TITLE
Fix AM/PM parsing

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -365,6 +365,8 @@ impl<'a> Collector for ParseCollector<'a> {
                     ParsingHour::FullDay(_) => {}
                     ParsingHour::HalfDay(_, current) => *current = h != 0,
                 }
+                // Consume AM/PM substring
+                self.s = &self.s[2..];
                 return Ok(());
             }
         }
@@ -641,6 +643,10 @@ mod tests {
         assert_eq!(
             parse_date_time_maybe_with_zone("%r", "12:34:56 AM")?,
             (datetime!(1900-01-01 00:34:56), None)
+        );
+        assert_eq!(
+            parse_date_time_maybe_with_zone("%r %F", "12:34:56 AM 2022-03-06")?,
+            (datetime!(2022-03-06 00:34:56), None)
         );
         assert_eq!(
             parse_date_time_maybe_with_zone("%R", "12: 4")?,


### PR DESCRIPTION
prior to this fix, the parsing of AM/PM substrings would fail unless they were located at the end of the input string.

e.g. `parse_date_time_maybe_with_zone("%r", "12:34:56 AM")` would work, 
whereas `parse_date_time_maybe_with_zone("%r %F", "12:34:56 AM 2022-03-06")` wouldn't