### PR TITLE
Add support for parsing and formatting %f

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -211,7 +211,7 @@ impl<'a, W: Write> Collector for FormatCollector<'a, W> {
     }
 
     #[inline]
-    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error> {
+    fn nanosecond_of_second(&mut self) -> Result<(), Self::Error> {
         let nanoseconds = self.time.nanosecond();
 
         let keep_digits: usize = if nanoseconds % 10 != 0 {

--- a/src/format.rs
+++ b/src/format.rs
@@ -233,7 +233,7 @@ impl<'a, W: Write> Collector for FormatCollector<'a, W> {
         } else if (nanoseconds / 100_000_000) % 10 != 0 {
             1
         } else {
-            0
+            9
         };
 
         let nanos_string = nanoseconds.to_string();
@@ -464,6 +464,7 @@ mod tests {
         test_datetime("%Y", datetime, "2022")?;
         test_datetime("%%", datetime, "%")?;
 
+        let datetime_ms0 = datetime!(2022-03-06 02:04:06);
         let datetime_ms1 = datetime!(2022-03-06 02:04:06.1);
         let datetime_ms2 = datetime!(2022-03-06 02:04:06.12);
         let datetime_ms3 = datetime!(2022-03-06 02:04:06.123);
@@ -474,6 +475,7 @@ mod tests {
         let datetime_ms8 = datetime!(2022-03-06 02:04:06.12345678);
         let datetime_ms9 = datetime!(2022-03-06 02:04:06.123456789);
 
+        test_datetime("%f", datetime_ms0, "000000000")?;
         test_datetime("%f", datetime_ms1, "1")?;
         test_datetime("%f", datetime_ms2, "12")?;
         test_datetime("%f", datetime_ms3, "123")?;

--- a/src/format.rs
+++ b/src/format.rs
@@ -212,39 +212,8 @@ impl<'a, W: Write> Collector for FormatCollector<'a, W> {
 
     #[inline]
     fn nanosecond_of_second(&mut self) -> Result<(), Self::Error> {
-        let nanoseconds = self.time.nanosecond();
-
-        let keep_digits: usize = if nanoseconds % 10 != 0 {
-            9
-        } else if (nanoseconds / 10) % 10 != 0 {
-            8
-        } else if (nanoseconds / 100) % 10 != 0 {
-            7
-        } else if (nanoseconds / 1_000) % 10 != 0 {
-            6
-        } else if (nanoseconds / 10_000) % 10 != 0 {
-            5
-        } else if (nanoseconds / 100_000) % 10 != 0 {
-            4
-        } else if (nanoseconds / 1_000_000) % 10 != 0 {
-            3
-        } else if (nanoseconds / 10_000_000) % 10 != 0 {
-            2
-        } else if (nanoseconds / 100_000_000) % 10 != 0 {
-            1
-        } else {
-            9
-        };
-
-        let nanos_string = nanoseconds.to_string();
-        let zeros_padding: usize = if nanos_string.len() == 9 { 0 } else { 9 };
-
         self.write
-            .write_fmt(
-                format_args!("{:0>padding$.precision$}", 
-                nanos_string, precision = keep_digits, padding = zeros_padding)
-            )?;
-
+            .write_fmt(format_args!("{:0>9}", self.time.nanosecond()))?;
         Ok(())
     }
 
@@ -476,14 +445,14 @@ mod tests {
         let datetime_ms9 = datetime!(2022-03-06 02:04:06.123456789);
 
         test_datetime("%f", datetime_ms0, "000000000")?;
-        test_datetime("%f", datetime_ms1, "1")?;
-        test_datetime("%f", datetime_ms2, "12")?;
-        test_datetime("%f", datetime_ms3, "123")?;
-        test_datetime("%f", datetime_ms4, "1234")?;
-        test_datetime("%f", datetime_ms5, "12345")?;
-        test_datetime("%f", datetime_ms6, "123456")?;
-        test_datetime("%f", datetime_ms7, "1234567")?;
-        test_datetime("%f", datetime_ms8, "12345678")?;
+        test_datetime("%f", datetime_ms1, "100000000")?;
+        test_datetime("%f", datetime_ms2, "120000000")?;
+        test_datetime("%f", datetime_ms3, "123000000")?;
+        test_datetime("%f", datetime_ms4, "123400000")?;
+        test_datetime("%f", datetime_ms5, "123450000")?;
+        test_datetime("%f", datetime_ms6, "123456000")?;
+        test_datetime("%f", datetime_ms7, "123456700")?;
+        test_datetime("%f", datetime_ms8, "123456780")?;
         test_datetime("%f", datetime_ms9, "123456789")?;
 
         let datetime_ms1 = datetime!(2022-03-06 02:04:06.900000000);
@@ -495,14 +464,14 @@ mod tests {
         let datetime_ms7 = datetime!(2022-03-06 02:04:06.987654300);
         let datetime_ms8 = datetime!(2022-03-06 02:04:06.987654320);
 
-        test_datetime("%f", datetime_ms1, "9")?;
-        test_datetime("%f", datetime_ms2, "98")?;
-        test_datetime("%f", datetime_ms3, "987")?;
-        test_datetime("%f", datetime_ms4, "9876")?;
-        test_datetime("%f", datetime_ms5, "98765")?;
-        test_datetime("%f", datetime_ms6, "987654")?;
-        test_datetime("%f", datetime_ms7, "9876543")?;
-        test_datetime("%f", datetime_ms8, "98765432")?;
+        test_datetime("%f", datetime_ms1, "900000000")?;
+        test_datetime("%f", datetime_ms2, "980000000")?;
+        test_datetime("%f", datetime_ms3, "987000000")?;
+        test_datetime("%f", datetime_ms4, "987600000")?;
+        test_datetime("%f", datetime_ms5, "987650000")?;
+        test_datetime("%f", datetime_ms6, "987654000")?;
+        test_datetime("%f", datetime_ms7, "987654300")?;
+        test_datetime("%f", datetime_ms8, "987654320")?;
 
         let datetime_ms1 = datetime!(2022-03-06 02:04:06.000000002);
         let datetime_ms2 = datetime!(2022-03-06 02:04:06.000000022);

--- a/src/format/spec_parser.rs
+++ b/src/format/spec_parser.rs
@@ -99,6 +99,8 @@ pub(crate) trait Collector {
     }
     /// `%S`. `00` to `60`.
     fn second_of_minute(&mut self) -> Result<(), Self::Error>;
+    /// `%f`. `000000000` to `999999999`.
+    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error>;
     /// `%t`.
     #[inline]
     fn tab(&mut self) -> Result<(), Self::Error> {
@@ -221,6 +223,7 @@ pub(crate) fn parse_conversion_specifications<C: Collector>(
                 b'r' => collector.time_ampm()?,
                 b'R' => collector.hour_minute_of_day()?,
                 b'S' => collector.second_of_minute()?,
+                b'f' => collector.nanosecond_of_minute()?,
                 b't' => collector.tab()?,
                 b'T' => collector.time_of_day()?,
                 b'u' => collector.day_of_week_from_monday_as_1()?,

--- a/src/format/spec_parser.rs
+++ b/src/format/spec_parser.rs
@@ -100,7 +100,7 @@ pub(crate) trait Collector {
     /// `%S`. `00` to `60`.
     fn second_of_minute(&mut self) -> Result<(), Self::Error>;
     /// `%f`. `000000000` to `999999999`.
-    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error>;
+    fn nanosecond_of_second(&mut self) -> Result<(), Self::Error>;
     /// `%t`.
     #[inline]
     fn tab(&mut self) -> Result<(), Self::Error> {
@@ -223,7 +223,7 @@ pub(crate) fn parse_conversion_specifications<C: Collector>(
                 b'r' => collector.time_ampm()?,
                 b'R' => collector.hour_minute_of_day()?,
                 b'S' => collector.second_of_minute()?,
-                b'f' => collector.nanosecond_of_minute()?,
+                b'f' => collector.nanosecond_of_second()?,
                 b't' => collector.tab()?,
                 b'T' => collector.time_of_day()?,
                 b'u' => collector.day_of_week_from_monday_as_1()?,

--- a/src/format/time_format_item.rs
+++ b/src/format/time_format_item.rs
@@ -198,7 +198,7 @@ impl<'a> Collector for ToFormatItemCollector<'a> {
     }
 
     #[inline]
-    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error> {
+    fn nanosecond_of_second(&mut self) -> Result<(), Self::Error> {
         let modifier = modifier::Subsecond::default();
         self.items
             .push(FormatItem::Component(Component::Subsecond(modifier)));

--- a/src/format/time_format_item.rs
+++ b/src/format/time_format_item.rs
@@ -198,6 +198,14 @@ impl<'a> Collector for ToFormatItemCollector<'a> {
     }
 
     #[inline]
+    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error> {
+        let modifier = modifier::Subsecond::default();
+        self.items
+            .push(FormatItem::Component(Component::Subsecond(modifier)));
+        Ok(())
+    }
+
+    #[inline]
     fn day_of_week_from_monday_as_1(&mut self) -> Result<(), Self::Error> {
         let mut modifier = modifier::Weekday::default();
         modifier.repr = modifier::WeekdayRepr::Monday;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -394,7 +394,7 @@ impl<'a> Collector for ParseCollector<'a> {
     }
 
     #[inline]
-    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error> {
+    fn nanosecond_of_second(&mut self) -> Result<(), Self::Error> {
         let input_length = self.s.len();
         let nanosecond: u32 = self.parse_nat(1, 9)?;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -47,6 +47,13 @@ impl Nat for u16 {
         v as u16
     }
 }
+impl Nat for u32 {
+    const ZERO: Self = 0;
+    const TEN: Self = 10;
+    fn from_u8(v: u8) -> Self {
+        v as u32
+    }
+}
 impl Nat for i16 {
     const ZERO: Self = 0;
     const TEN: Self = 10;
@@ -96,6 +103,7 @@ struct ParseCollector<'a> {
     hour: ParsingHour,
     minute: u8,
     second: u8,
+    nanosecond: u32,
     zone: Option<TimeZoneSpecifier<'a>>,
 }
 impl<'a> ParseCollector<'a> {
@@ -107,6 +115,7 @@ impl<'a> ParseCollector<'a> {
             hour: ParsingHour::Unspecified,
             minute: 0,
             second: 0,
+            nanosecond: 0,
             zone: None,
         }
     }
@@ -385,6 +394,20 @@ impl<'a> Collector for ParseCollector<'a> {
     }
 
     #[inline]
+    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error> {
+        let input_length = self.s.len();
+        let nanosecond: u32 = self.parse_nat(1, 9)?;
+
+        let digits_consumed = input_length - self.s.len();
+        static SCALE: [u32; 10] = [
+            0, 100_000_000, 10_000_000, 1_000_000, 100_000, 10_000, 1_000, 100, 10, 1
+        ];
+        self.nanosecond = nanosecond * SCALE[digits_consumed];
+
+        Ok(())
+    }
+
+    #[inline]
     fn week_number_of_current_year_start_sunday(&mut self) -> Result<(), Self::Error> {
         let w: u8 = self.parse_nat(1, 2)?;
         if (0..=53).contains(&w) {
@@ -535,7 +558,7 @@ impl<'a> Collector for ParseCollector<'a> {
                 }
             }
         };
-        let time = Time::from_hms(hour, self.minute, self.second)?;
+        let time = Time::from_hms_nano(hour, self.minute, self.second, self.nanosecond)?;
         let zone = self.zone;
         Ok((PrimitiveDateTime::new(date, time), zone))
     }
@@ -659,6 +682,18 @@ mod tests {
         assert_eq!(
             parse_date_time_maybe_with_zone("%T", "01:23:45")?,
             (datetime!(1900-01-01 01:23:45), None)
+        );
+        assert_eq!(
+            parse_date_time_maybe_with_zone("%T.%f", "01:23:45.123")?,
+            (datetime!(1900-01-01 01:23:45.123), None)
+        );
+        assert_eq!(
+            parse_date_time_maybe_with_zone("%T.%f", "01:23:45.12300")?,
+            (datetime!(1900-01-01 01:23:45.123), None)
+        );
+        assert_eq!(
+            parse_date_time_maybe_with_zone("%T.%f", "01:23:45.000001234")?,
+            (datetime!(1900-01-01 01:23:45.000001234), None)
         );
         assert_eq!(
             parse_date_time_maybe_with_zone("%U", "1")?,

--- a/src/parse/desc_parser.rs
+++ b/src/parse/desc_parser.rs
@@ -95,6 +95,8 @@ pub(crate) trait Collector {
     }
     /// `%S`. `00` to `60`.
     fn second_of_minute(&mut self) -> Result<(), Self::Error>;
+    /// `%f`. `000000000` to `999999999`.
+    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error>;
     /// `%t`.
     #[inline]
     fn tab(&mut self) -> Result<(), Self::Error> {
@@ -213,6 +215,7 @@ pub(crate) fn parse_format_specifications<C: Collector>(
                 b'r' => collector.time_ampm()?,
                 b'R' => collector.hour_minute_of_day()?,
                 b'S' => collector.second_of_minute()?,
+                b'f' => collector.nanosecond_of_minute()?,
                 b't' => collector.tab()?,
                 b'T' => collector.time_of_day()?,
                 b'U' => collector.week_number_of_current_year_start_sunday()?,

--- a/src/parse/desc_parser.rs
+++ b/src/parse/desc_parser.rs
@@ -96,7 +96,7 @@ pub(crate) trait Collector {
     /// `%S`. `00` to `60`.
     fn second_of_minute(&mut self) -> Result<(), Self::Error>;
     /// `%f`. `000000000` to `999999999`.
-    fn nanosecond_of_minute(&mut self) -> Result<(), Self::Error>;
+    fn nanosecond_of_second(&mut self) -> Result<(), Self::Error>;
     /// `%t`.
     #[inline]
     fn tab(&mut self) -> Result<(), Self::Error> {
@@ -215,7 +215,7 @@ pub(crate) fn parse_format_specifications<C: Collector>(
                 b'r' => collector.time_ampm()?,
                 b'R' => collector.hour_minute_of_day()?,
                 b'S' => collector.second_of_minute()?,
-                b'f' => collector.nanosecond_of_minute()?,
+                b'f' => collector.nanosecond_of_second()?,
                 b't' => collector.tab()?,
                 b'T' => collector.time_of_day()?,
                 b'U' => collector.week_number_of_current_year_start_sunday()?,


### PR DESCRIPTION
Even though the `%f` specifier is not part of strptime(3), `time` supports (date)times with nanosecond precision. 

The implementation behaves like [Python's `%f`](https://docs.python.org/3/library/datetime.html), however the number is zero-padded up to 9 digits (compared to Python's 6 digits).